### PR TITLE
Fix dbFlags default to null

### DIFF
--- a/fcs.py
+++ b/fcs.py
@@ -567,7 +567,7 @@ def fcs_update_helidb(interval):
             if "dbFlags" in plane:
                 dbFlags = plane["dbFlags"]
             else:
-                dbFlags = ""
+                dbFlags = None
 
             if "ownOp" in plane:
                 ownOp = plane["ownOp"]


### PR DESCRIPTION
Fixes dbFlags default when missing so properties.dbFlags becomes null rather than empty string.

Closes #39.