### PR TITLE
Keep Mongo connection logs at info level

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,20 @@ cp  example_dot_env .env
 Add your credentials or API-key, and Feeder-ID type to the .env file.
 MongoDB Atlas connections from this service are labeled with app name `CopterFeeder`.
 
+MongoClient connection logging is enabled by default to help troubleshoot per-instance
+connection usage. You can control it with:
+
+```Shell
+MONGO_CONN_LOG_ENABLED=true
+MONGO_CONN_LOG_INTERVAL_SECS=60
+```
+
+Sample log line:
+
+```Code
+Mongo Connections feeder_id=Daniel-prod open_connections_current=3 connections_opened_total=5 connections_closed_total=2
+```
+
 ```Shell
 nano .env
 ```


### PR DESCRIPTION
Summary
- ensure the mongo connection logging stays at info level rather than verbose so normal runs are quieter
- revert the earlier change attempting to require `-v` for those logs

Testing
- Not run (not requested)