### PR TITLE
Add ADS-B feeder healthcheck skill

### DIFF
--- a/.agents/skills/adsb-feeder-healthcheck/SKILL.md
+++ b/.agents/skills/adsb-feeder-healthcheck/SKILL.md
@@ -15,6 +15,11 @@ This skill is a direct conversion of the CopterSpotter runbook in `references/so
 - You need a reproducible feeder report for a fixed historical range.
 - The workflow should use MongoDB MCP aggregations instead of ad hoc shell or database commands.
 
+## Prerequisites
+
+- This skill requires MongoDB MCP access.
+- If MongoDB MCP is unavailable or not connected, stop and ask the user to provide or connect it.
+
 ## Workflow
 
 ### 1. Discover repo defaults before asking

--- a/.agents/skills/adsb-feeder-healthcheck/SKILL.md
+++ b/.agents/skills/adsb-feeder-healthcheck/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: adsb-feeder-healthcheck
+description: Convert the CopterSpotter ADS-B feeder healthcheck runbook into a reusable MongoDB MCP workflow for checking feeder activity, feeder last-seen timestamps, and fixed-range feeder history across one or two ADS-B collections.
+---
+
+# ADS-B Feeder Healthcheck
+
+This skill is a direct conversion of the CopterSpotter runbook in `references/source-runbook-notes.md`. Preserve that workflow first, then generalize only the repo-specific defaults so the same process works from `copterspotter`, `CopterFeeder`, or another ADS-B repo.
+
+## Use This Skill When
+
+- You need to check which feeders have sent data recently.
+- You need the last-seen timestamp per feeder across all available ADS-B data.
+- You need to find feeders whose names match a substring.
+- You need a reproducible feeder report for a fixed historical range.
+- The workflow should use MongoDB MCP aggregations instead of ad hoc shell or database commands.
+
+## Workflow
+
+### 1. Discover repo defaults before asking
+
+Read the current repo in this order:
+
+1. `AGENTS.md`
+2. Repo docs or runbooks
+3. Code or config that names the Mongo database, collections, and field paths
+
+Use `references/repo-discovery.md` for the expected cues in `copterspotter`, `CopterFeeder`, or an unfamiliar repo.
+
+If the repo clearly establishes the Mongo target, continue without asking the user.
+
+If the repo does not clearly establish the Mongo target, ask for:
+
+- database name
+- base collection name
+- optional secondary collection name
+- feeder field path
+- timestamp field path
+
+### 2. Keep the original query semantics
+
+Match the source runbook behavior. Do not broaden the semantics unless the user explicitly asks for a different report.
+
+Supported query modes:
+
+- feeders active in the last `N` hours
+- last-seen per feeder across all data
+- last-seen for feeders matching a substring
+- fixed historical date range
+
+Use `references/query-recipes.md` for the aggregation templates. Replace placeholder collection names and field paths before sending the MCP call.
+
+### 3. Prefer MongoDB MCP aggregations
+
+- Run the aggregation on the primary collection.
+- Use `$unionWith` for the optional secondary collection when one exists.
+- If the repo only confirms one collection, remove the `$unionWith` stage and say so in the report.
+- Keep the pipeline shape aligned with the source runbook.
+
+### 4. Return a complete report
+
+Every final answer should include:
+
+- database used
+- collection or collections used
+- feeder field path used
+- timestamp field path used
+- query mode used
+- time window or fixed range used
+- feeder filter used, if any
+- result summary with feeder names, counts, and latest timestamps
+
+## Guardrails
+
+- The source runbook wins when there is ambiguity.
+- Do not assume `HelicoptersofDC-2023`, `ADSB`, or `ADSB-mil` unless the repo or the user confirms them.
+- Do not assume `properties.feeder` or `properties.jsDate` unless the repo or the user confirms them.
+- Prefer discovery from repo docs and code before asking the user for missing values.
+- If field types are unclear, stop and confirm before writing a Mongo aggregation.
+- When editing this skill later, keep `references/source-runbook-notes.md` aligned with the runbook it was derived from.
+
+## Resources
+
+- `references/source-runbook-notes.md`: mapping from the CopterSpotter runbook to this skill
+- `references/repo-discovery.md`: discovery order and repo-specific cues
+- `references/query-recipes.md`: aggregation templates with placeholders

--- a/.agents/skills/adsb-feeder-healthcheck/agents/openai.yaml
+++ b/.agents/skills/adsb-feeder-healthcheck/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ADSB Feeder Healthcheck"
+  short_description: "Check ADS-B feeder activity in MongoDB"
+  default_prompt: "Use $adsb-feeder-healthcheck to inspect feeder recency or last-seen activity with MongoDB MCP."

--- a/.agents/skills/adsb-feeder-healthcheck/references/query-recipes.md
+++ b/.agents/skills/adsb-feeder-healthcheck/references/query-recipes.md
@@ -1,0 +1,180 @@
+# Query recipes
+
+Replace the placeholders before sending the MongoDB MCP call.
+
+Placeholder names:
+
+- `PRIMARY_COLLECTION`
+- `SECONDARY_COLLECTION`
+- `FEEDER_FIELD`
+- `TIMESTAMP_FIELD`
+- `HOURS`
+- `MATCH_PATTERN`
+- `START_ISO`
+- `END_ISO`
+
+If there is no secondary collection, remove the `$unionWith` stage and say that the report used a single collection.
+
+## Rolling window
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "$expr": {
+        "$and": [
+          {
+            "$gte": [
+              "$TIMESTAMP_FIELD",
+              {
+                "$dateSubtract": {
+                  "startDate": "$$NOW",
+                  "unit": "hour",
+                  "amount": HOURS
+                }
+              }
+            ]
+          },
+          { "$lte": ["$TIMESTAMP_FIELD", "$$NOW"] }
+        ]
+      }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "$expr": {
+              "$and": [
+                {
+                  "$gte": [
+                    "$TIMESTAMP_FIELD",
+                    {
+                      "$dateSubtract": {
+                        "startDate": "$$NOW",
+                        "unit": "hour",
+                        "amount": HOURS
+                      }
+                    }
+                  ]
+                },
+                { "$lte": ["$TIMESTAMP_FIELD", "$$NOW"] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "count": -1, "latest": -1 } }
+]
+```
+
+## All feeders
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  { "$unionWith": { "coll": "SECONDARY_COLLECTION" } },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "latest": -1, "count": -1 } }
+]
+```
+
+## Substring match
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "FEEDER_FIELD": { "$regex": "MATCH_PATTERN", "$options": "i" }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "FEEDER_FIELD": { "$regex": "MATCH_PATTERN", "$options": "i" }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "latest": -1, "count": -1 } }
+]
+```
+
+## Fixed range
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "TIMESTAMP_FIELD": {
+        "$gte": { "$date": "START_ISO" },
+        "$lte": { "$date": "END_ISO" }
+      }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "TIMESTAMP_FIELD": {
+              "$gte": { "$date": "START_ISO" },
+              "$lte": { "$date": "END_ISO" }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "count": -1, "latest": -1 } }
+]
+```
+
+## Notes
+
+- Replace quoted field placeholders with the actual dotted field path before sending the MCP call.
+- Keep the report grouped by feeder and include the latest timestamp per feeder.
+- Use UTC ISO timestamps for fixed ranges unless the user explicitly wants another timezone interpretation.

--- a/.agents/skills/adsb-feeder-healthcheck/references/repo-discovery.md
+++ b/.agents/skills/adsb-feeder-healthcheck/references/repo-discovery.md
@@ -1,0 +1,56 @@
+# Repo discovery
+
+Use repo evidence before asking the user for Mongo details.
+
+## Discovery order
+
+1. Read `AGENTS.md`.
+2. Read repo docs or runbooks related to ADS-B, Mongo, routes, or operations.
+3. Search code for:
+   - database names
+   - collection names
+   - `properties.feeder`
+   - `properties.jsDate`
+   - `$unionWith`
+   - ADS-B route or ingestion code
+
+If the repo still does not establish the target clearly, ask for the missing database, collection, and field-path values.
+
+## CopterSpotter cues
+
+- `copterspotter/.cursor/rules/adsb-feeder-healthcheck.mdc`
+  - Establishes the original runbook behavior
+  - Names `HelicoptersofDC-2023`, `ADSB`, `ADSB-mil`, `properties.feeder`, and `properties.jsDate`
+- `copterspotter/.cursor/rules/adsb-routes.mdc`
+  - Links to the feeder healthcheck runbook as an operational runbook
+- `copterspotter/routes/adsbLookupCore.js`
+  - Confirms the `ADSB` plus `ADSB-mil` aggregation pattern
+  - Confirms `properties.jsDate` usage in Mongo queries
+- `copterspotter/routes/adsbRoutes.js`
+  - Repeats the primary-plus-secondary collection pattern with `$unionWith`
+
+For `copterspotter`, the runbook is the strongest evidence source. Use it first.
+
+## CopterFeeder cues
+
+- `CopterFeeder/AGENTS.md`
+  - Confirms the repo writes rotorcraft data into a MongoDB-backed API flow
+- `CopterFeeder/fcs.py`
+  - Confirms the database name `HelicoptersofDC-2023`
+  - Confirms collection selection between `ADSB` and `ADSB-mil`
+
+`CopterFeeder` does not expose the feeder healthcheck runbook itself, so inspect code before assuming field paths. If field-path evidence is missing in the repo, ask the user to confirm them.
+
+## Unknown repo checklist
+
+Look for one or more of these patterns:
+
+- `db.collection("...")`
+- `myclient["..."]`
+- `$unionWith`
+- `properties.feeder`
+- `properties.jsDate`
+- feeder identifiers written during ingestion
+- report or healthcheck docs that mention ADS-B or feeder recency
+
+If you only find partial evidence, state what was discovered and ask only for the missing values.

--- a/.agents/skills/adsb-feeder-healthcheck/references/source-runbook-notes.md
+++ b/.agents/skills/adsb-feeder-healthcheck/references/source-runbook-notes.md
@@ -1,0 +1,37 @@
+# Source runbook mapping
+
+This skill is derived from `copterspotter/.cursor/rules/adsb-feeder-healthcheck.mdc`.
+
+## Section mapping
+
+- Runbook description and prerequisites:
+  - Skill sections `Use This Skill When`, `Workflow`, and `Guardrails`
+  - Converted from repo-specific defaults into a discovery-first workflow
+- Query 1: feeders with data in last N hours:
+  - Skill query mode `feeders active in the last N hours`
+  - Pipeline template in `query-recipes.md` under `Rolling window`
+- Query 2a: last date per feeder across all data:
+  - Skill query mode `last-seen per feeder across all data`
+  - Pipeline template in `query-recipes.md` under `All feeders`
+- Query 2b: feeders matching a name pattern:
+  - Skill query mode `last-seen for feeders matching a substring`
+  - Pipeline template in `query-recipes.md` under `Substring match`
+- Query 3: fixed date range:
+  - Skill query mode `fixed historical date range`
+  - Pipeline template in `query-recipes.md` under `Fixed range`
+- Runbook tips:
+  - Skill guidance to run against the primary collection and use `$unionWith` for the optional secondary collection
+  - Skill reminder that `$dateSubtract` requires MongoDB 5.0 or newer
+
+## What changed during conversion
+
+- Repo defaults are now discovered instead of assumed.
+- Collection names and field paths are parameterized with placeholders.
+- The reporting requirements are explicit so final answers always surface the exact database, collection set, and filter choices used.
+
+## What must stay aligned
+
+- The four supported query modes
+- `$unionWith`-based aggregation across one or two collections
+- Grouping by feeder and reporting the latest timestamp per feeder
+- The rule that runbook behavior wins if generalization would change semantics

--- a/.claude/skills/adsb-feeder-healthcheck/SKILL.md
+++ b/.claude/skills/adsb-feeder-healthcheck/SKILL.md
@@ -15,6 +15,11 @@ This skill is a direct conversion of the CopterSpotter runbook in `references/so
 - You need a reproducible feeder report for a fixed historical range.
 - The workflow should use MongoDB MCP aggregations instead of ad hoc shell or database commands.
 
+## Prerequisites
+
+- This skill requires MongoDB MCP access.
+- If MongoDB MCP is unavailable or not connected, stop and ask the user to provide or connect it.
+
 ## Workflow
 
 ### 1. Discover repo defaults before asking

--- a/.claude/skills/adsb-feeder-healthcheck/SKILL.md
+++ b/.claude/skills/adsb-feeder-healthcheck/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: adsb-feeder-healthcheck
+description: Convert the CopterSpotter ADS-B feeder healthcheck runbook into a reusable MongoDB MCP workflow for checking feeder activity, feeder last-seen timestamps, and fixed-range feeder history across one or two ADS-B collections.
+---
+
+# ADS-B Feeder Healthcheck
+
+This skill is a direct conversion of the CopterSpotter runbook in `references/source-runbook-notes.md`. Preserve that workflow first, then generalize only the repo-specific defaults so the same process works from `copterspotter`, `CopterFeeder`, or another ADS-B repo.
+
+## Use This Skill When
+
+- You need to check which feeders have sent data recently.
+- You need the last-seen timestamp per feeder across all available ADS-B data.
+- You need to find feeders whose names match a substring.
+- You need a reproducible feeder report for a fixed historical range.
+- The workflow should use MongoDB MCP aggregations instead of ad hoc shell or database commands.
+
+## Workflow
+
+### 1. Discover repo defaults before asking
+
+Read the current repo in this order:
+
+1. `AGENTS.md`
+2. Repo docs or runbooks
+3. Code or config that names the Mongo database, collections, and field paths
+
+Use `references/repo-discovery.md` for the expected cues in `copterspotter`, `CopterFeeder`, or an unfamiliar repo.
+
+If the repo clearly establishes the Mongo target, continue without asking the user.
+
+If the repo does not clearly establish the Mongo target, ask for:
+
+- database name
+- base collection name
+- optional secondary collection name
+- feeder field path
+- timestamp field path
+
+### 2. Keep the original query semantics
+
+Match the source runbook behavior. Do not broaden the semantics unless the user explicitly asks for a different report.
+
+Supported query modes:
+
+- feeders active in the last `N` hours
+- last-seen per feeder across all data
+- last-seen for feeders matching a substring
+- fixed historical date range
+
+Use `references/query-recipes.md` for the aggregation templates. Replace placeholder collection names and field paths before sending the MCP call.
+
+### 3. Prefer MongoDB MCP aggregations
+
+- Run the aggregation on the primary collection.
+- Use `$unionWith` for the optional secondary collection when one exists.
+- If the repo only confirms one collection, remove the `$unionWith` stage and say so in the report.
+- Keep the pipeline shape aligned with the source runbook.
+
+### 4. Return a complete report
+
+Every final answer should include:
+
+- database used
+- collection or collections used
+- feeder field path used
+- timestamp field path used
+- query mode used
+- time window or fixed range used
+- feeder filter used, if any
+- result summary with feeder names, counts, and latest timestamps
+
+## Guardrails
+
+- The source runbook wins when there is ambiguity.
+- Do not assume `HelicoptersofDC-2023`, `ADSB`, or `ADSB-mil` unless the repo or the user confirms them.
+- Do not assume `properties.feeder` or `properties.jsDate` unless the repo or the user confirms them.
+- Prefer discovery from repo docs and code before asking the user for missing values.
+- If field types are unclear, stop and confirm before writing a Mongo aggregation.
+- When editing this skill later, keep `references/source-runbook-notes.md` aligned with the runbook it was derived from.
+
+## Resources
+
+- `references/source-runbook-notes.md`: mapping from the CopterSpotter runbook to this skill
+- `references/repo-discovery.md`: discovery order and repo-specific cues
+- `references/query-recipes.md`: aggregation templates with placeholders

--- a/.claude/skills/adsb-feeder-healthcheck/agents/openai.yaml
+++ b/.claude/skills/adsb-feeder-healthcheck/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ADSB Feeder Healthcheck"
+  short_description: "Check ADS-B feeder activity in MongoDB"
+  default_prompt: "Use $adsb-feeder-healthcheck to inspect feeder recency or last-seen activity with MongoDB MCP."

--- a/.claude/skills/adsb-feeder-healthcheck/references/query-recipes.md
+++ b/.claude/skills/adsb-feeder-healthcheck/references/query-recipes.md
@@ -1,0 +1,180 @@
+# Query recipes
+
+Replace the placeholders before sending the MongoDB MCP call.
+
+Placeholder names:
+
+- `PRIMARY_COLLECTION`
+- `SECONDARY_COLLECTION`
+- `FEEDER_FIELD`
+- `TIMESTAMP_FIELD`
+- `HOURS`
+- `MATCH_PATTERN`
+- `START_ISO`
+- `END_ISO`
+
+If there is no secondary collection, remove the `$unionWith` stage and say that the report used a single collection.
+
+## Rolling window
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "$expr": {
+        "$and": [
+          {
+            "$gte": [
+              "$TIMESTAMP_FIELD",
+              {
+                "$dateSubtract": {
+                  "startDate": "$$NOW",
+                  "unit": "hour",
+                  "amount": HOURS
+                }
+              }
+            ]
+          },
+          { "$lte": ["$TIMESTAMP_FIELD", "$$NOW"] }
+        ]
+      }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "$expr": {
+              "$and": [
+                {
+                  "$gte": [
+                    "$TIMESTAMP_FIELD",
+                    {
+                      "$dateSubtract": {
+                        "startDate": "$$NOW",
+                        "unit": "hour",
+                        "amount": HOURS
+                      }
+                    }
+                  ]
+                },
+                { "$lte": ["$TIMESTAMP_FIELD", "$$NOW"] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "count": -1, "latest": -1 } }
+]
+```
+
+## All feeders
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  { "$unionWith": { "coll": "SECONDARY_COLLECTION" } },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "latest": -1, "count": -1 } }
+]
+```
+
+## Substring match
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "FEEDER_FIELD": { "$regex": "MATCH_PATTERN", "$options": "i" }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "FEEDER_FIELD": { "$regex": "MATCH_PATTERN", "$options": "i" }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "latest": -1, "count": -1 } }
+]
+```
+
+## Fixed range
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "TIMESTAMP_FIELD": {
+        "$gte": { "$date": "START_ISO" },
+        "$lte": { "$date": "END_ISO" }
+      }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "TIMESTAMP_FIELD": {
+              "$gte": { "$date": "START_ISO" },
+              "$lte": { "$date": "END_ISO" }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "count": -1, "latest": -1 } }
+]
+```
+
+## Notes
+
+- Replace quoted field placeholders with the actual dotted field path before sending the MCP call.
+- Keep the report grouped by feeder and include the latest timestamp per feeder.
+- Use UTC ISO timestamps for fixed ranges unless the user explicitly wants another timezone interpretation.

--- a/.claude/skills/adsb-feeder-healthcheck/references/repo-discovery.md
+++ b/.claude/skills/adsb-feeder-healthcheck/references/repo-discovery.md
@@ -1,0 +1,56 @@
+# Repo discovery
+
+Use repo evidence before asking the user for Mongo details.
+
+## Discovery order
+
+1. Read `AGENTS.md`.
+2. Read repo docs or runbooks related to ADS-B, Mongo, routes, or operations.
+3. Search code for:
+   - database names
+   - collection names
+   - `properties.feeder`
+   - `properties.jsDate`
+   - `$unionWith`
+   - ADS-B route or ingestion code
+
+If the repo still does not establish the target clearly, ask for the missing database, collection, and field-path values.
+
+## CopterSpotter cues
+
+- `copterspotter/.cursor/rules/adsb-feeder-healthcheck.mdc`
+  - Establishes the original runbook behavior
+  - Names `HelicoptersofDC-2023`, `ADSB`, `ADSB-mil`, `properties.feeder`, and `properties.jsDate`
+- `copterspotter/.cursor/rules/adsb-routes.mdc`
+  - Links to the feeder healthcheck runbook as an operational runbook
+- `copterspotter/routes/adsbLookupCore.js`
+  - Confirms the `ADSB` plus `ADSB-mil` aggregation pattern
+  - Confirms `properties.jsDate` usage in Mongo queries
+- `copterspotter/routes/adsbRoutes.js`
+  - Repeats the primary-plus-secondary collection pattern with `$unionWith`
+
+For `copterspotter`, the runbook is the strongest evidence source. Use it first.
+
+## CopterFeeder cues
+
+- `CopterFeeder/AGENTS.md`
+  - Confirms the repo writes rotorcraft data into a MongoDB-backed API flow
+- `CopterFeeder/fcs.py`
+  - Confirms the database name `HelicoptersofDC-2023`
+  - Confirms collection selection between `ADSB` and `ADSB-mil`
+
+`CopterFeeder` does not expose the feeder healthcheck runbook itself, so inspect code before assuming field paths. If field-path evidence is missing in the repo, ask the user to confirm them.
+
+## Unknown repo checklist
+
+Look for one or more of these patterns:
+
+- `db.collection("...")`
+- `myclient["..."]`
+- `$unionWith`
+- `properties.feeder`
+- `properties.jsDate`
+- feeder identifiers written during ingestion
+- report or healthcheck docs that mention ADS-B or feeder recency
+
+If you only find partial evidence, state what was discovered and ask only for the missing values.

--- a/.claude/skills/adsb-feeder-healthcheck/references/source-runbook-notes.md
+++ b/.claude/skills/adsb-feeder-healthcheck/references/source-runbook-notes.md
@@ -1,0 +1,37 @@
+# Source runbook mapping
+
+This skill is derived from `copterspotter/.cursor/rules/adsb-feeder-healthcheck.mdc`.
+
+## Section mapping
+
+- Runbook description and prerequisites:
+  - Skill sections `Use This Skill When`, `Workflow`, and `Guardrails`
+  - Converted from repo-specific defaults into a discovery-first workflow
+- Query 1: feeders with data in last N hours:
+  - Skill query mode `feeders active in the last N hours`
+  - Pipeline template in `query-recipes.md` under `Rolling window`
+- Query 2a: last date per feeder across all data:
+  - Skill query mode `last-seen per feeder across all data`
+  - Pipeline template in `query-recipes.md` under `All feeders`
+- Query 2b: feeders matching a name pattern:
+  - Skill query mode `last-seen for feeders matching a substring`
+  - Pipeline template in `query-recipes.md` under `Substring match`
+- Query 3: fixed date range:
+  - Skill query mode `fixed historical date range`
+  - Pipeline template in `query-recipes.md` under `Fixed range`
+- Runbook tips:
+  - Skill guidance to run against the primary collection and use `$unionWith` for the optional secondary collection
+  - Skill reminder that `$dateSubtract` requires MongoDB 5.0 or newer
+
+## What changed during conversion
+
+- Repo defaults are now discovered instead of assumed.
+- Collection names and field paths are parameterized with placeholders.
+- The reporting requirements are explicit so final answers always surface the exact database, collection set, and filter choices used.
+
+## What must stay aligned
+
+- The four supported query modes
+- `$unionWith`-based aggregation across one or two collections
+- Grouping by feeder and reporting the latest timestamp per feeder
+- The rule that runbook behavior wins if generalization would change semantics

--- a/.cursor/skills/adsb-feeder-healthcheck/SKILL.md
+++ b/.cursor/skills/adsb-feeder-healthcheck/SKILL.md
@@ -15,6 +15,11 @@ This skill is a direct conversion of the CopterSpotter runbook in `references/so
 - You need a reproducible feeder report for a fixed historical range.
 - The workflow should use MongoDB MCP aggregations instead of ad hoc shell or database commands.
 
+## Prerequisites
+
+- This skill requires MongoDB MCP access.
+- If MongoDB MCP is unavailable or not connected, stop and ask the user to provide or connect it.
+
 ## Workflow
 
 ### 1. Discover repo defaults before asking

--- a/.cursor/skills/adsb-feeder-healthcheck/SKILL.md
+++ b/.cursor/skills/adsb-feeder-healthcheck/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: adsb-feeder-healthcheck
+description: Convert the CopterSpotter ADS-B feeder healthcheck runbook into a reusable MongoDB MCP workflow for checking feeder activity, feeder last-seen timestamps, and fixed-range feeder history across one or two ADS-B collections.
+---
+
+# ADS-B Feeder Healthcheck
+
+This skill is a direct conversion of the CopterSpotter runbook in `references/source-runbook-notes.md`. Preserve that workflow first, then generalize only the repo-specific defaults so the same process works from `copterspotter`, `CopterFeeder`, or another ADS-B repo.
+
+## Use This Skill When
+
+- You need to check which feeders have sent data recently.
+- You need the last-seen timestamp per feeder across all available ADS-B data.
+- You need to find feeders whose names match a substring.
+- You need a reproducible feeder report for a fixed historical range.
+- The workflow should use MongoDB MCP aggregations instead of ad hoc shell or database commands.
+
+## Workflow
+
+### 1. Discover repo defaults before asking
+
+Read the current repo in this order:
+
+1. `AGENTS.md`
+2. Repo docs or runbooks
+3. Code or config that names the Mongo database, collections, and field paths
+
+Use `references/repo-discovery.md` for the expected cues in `copterspotter`, `CopterFeeder`, or an unfamiliar repo.
+
+If the repo clearly establishes the Mongo target, continue without asking the user.
+
+If the repo does not clearly establish the Mongo target, ask for:
+
+- database name
+- base collection name
+- optional secondary collection name
+- feeder field path
+- timestamp field path
+
+### 2. Keep the original query semantics
+
+Match the source runbook behavior. Do not broaden the semantics unless the user explicitly asks for a different report.
+
+Supported query modes:
+
+- feeders active in the last `N` hours
+- last-seen per feeder across all data
+- last-seen for feeders matching a substring
+- fixed historical date range
+
+Use `references/query-recipes.md` for the aggregation templates. Replace placeholder collection names and field paths before sending the MCP call.
+
+### 3. Prefer MongoDB MCP aggregations
+
+- Run the aggregation on the primary collection.
+- Use `$unionWith` for the optional secondary collection when one exists.
+- If the repo only confirms one collection, remove the `$unionWith` stage and say so in the report.
+- Keep the pipeline shape aligned with the source runbook.
+
+### 4. Return a complete report
+
+Every final answer should include:
+
+- database used
+- collection or collections used
+- feeder field path used
+- timestamp field path used
+- query mode used
+- time window or fixed range used
+- feeder filter used, if any
+- result summary with feeder names, counts, and latest timestamps
+
+## Guardrails
+
+- The source runbook wins when there is ambiguity.
+- Do not assume `HelicoptersofDC-2023`, `ADSB`, or `ADSB-mil` unless the repo or the user confirms them.
+- Do not assume `properties.feeder` or `properties.jsDate` unless the repo or the user confirms them.
+- Prefer discovery from repo docs and code before asking the user for missing values.
+- If field types are unclear, stop and confirm before writing a Mongo aggregation.
+- When editing this skill later, keep `references/source-runbook-notes.md` aligned with the runbook it was derived from.
+
+## Resources
+
+- `references/source-runbook-notes.md`: mapping from the CopterSpotter runbook to this skill
+- `references/repo-discovery.md`: discovery order and repo-specific cues
+- `references/query-recipes.md`: aggregation templates with placeholders

--- a/.cursor/skills/adsb-feeder-healthcheck/agents/openai.yaml
+++ b/.cursor/skills/adsb-feeder-healthcheck/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ADSB Feeder Healthcheck"
+  short_description: "Check ADS-B feeder activity in MongoDB"
+  default_prompt: "Use $adsb-feeder-healthcheck to inspect feeder recency or last-seen activity with MongoDB MCP."

--- a/.cursor/skills/adsb-feeder-healthcheck/references/query-recipes.md
+++ b/.cursor/skills/adsb-feeder-healthcheck/references/query-recipes.md
@@ -1,0 +1,180 @@
+# Query recipes
+
+Replace the placeholders before sending the MongoDB MCP call.
+
+Placeholder names:
+
+- `PRIMARY_COLLECTION`
+- `SECONDARY_COLLECTION`
+- `FEEDER_FIELD`
+- `TIMESTAMP_FIELD`
+- `HOURS`
+- `MATCH_PATTERN`
+- `START_ISO`
+- `END_ISO`
+
+If there is no secondary collection, remove the `$unionWith` stage and say that the report used a single collection.
+
+## Rolling window
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "$expr": {
+        "$and": [
+          {
+            "$gte": [
+              "$TIMESTAMP_FIELD",
+              {
+                "$dateSubtract": {
+                  "startDate": "$$NOW",
+                  "unit": "hour",
+                  "amount": HOURS
+                }
+              }
+            ]
+          },
+          { "$lte": ["$TIMESTAMP_FIELD", "$$NOW"] }
+        ]
+      }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "$expr": {
+              "$and": [
+                {
+                  "$gte": [
+                    "$TIMESTAMP_FIELD",
+                    {
+                      "$dateSubtract": {
+                        "startDate": "$$NOW",
+                        "unit": "hour",
+                        "amount": HOURS
+                      }
+                    }
+                  ]
+                },
+                { "$lte": ["$TIMESTAMP_FIELD", "$$NOW"] }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "count": -1, "latest": -1 } }
+]
+```
+
+## All feeders
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  { "$unionWith": { "coll": "SECONDARY_COLLECTION" } },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "latest": -1, "count": -1 } }
+]
+```
+
+## Substring match
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "FEEDER_FIELD": { "$regex": "MATCH_PATTERN", "$options": "i" }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "FEEDER_FIELD": { "$regex": "MATCH_PATTERN", "$options": "i" }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "latest": -1, "count": -1 } }
+]
+```
+
+## Fixed range
+
+Run on `PRIMARY_COLLECTION`.
+
+```json
+[
+  {
+    "$match": {
+      "TIMESTAMP_FIELD": {
+        "$gte": { "$date": "START_ISO" },
+        "$lte": { "$date": "END_ISO" }
+      }
+    }
+  },
+  {
+    "$unionWith": {
+      "coll": "SECONDARY_COLLECTION",
+      "pipeline": [
+        {
+          "$match": {
+            "TIMESTAMP_FIELD": {
+              "$gte": { "$date": "START_ISO" },
+              "$lte": { "$date": "END_ISO" }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "$group": {
+      "_id": "$FEEDER_FIELD",
+      "count": { "$sum": 1 },
+      "latest": { "$max": "$TIMESTAMP_FIELD" }
+    }
+  },
+  { "$sort": { "count": -1, "latest": -1 } }
+]
+```
+
+## Notes
+
+- Replace quoted field placeholders with the actual dotted field path before sending the MCP call.
+- Keep the report grouped by feeder and include the latest timestamp per feeder.
+- Use UTC ISO timestamps for fixed ranges unless the user explicitly wants another timezone interpretation.

--- a/.cursor/skills/adsb-feeder-healthcheck/references/repo-discovery.md
+++ b/.cursor/skills/adsb-feeder-healthcheck/references/repo-discovery.md
@@ -1,0 +1,56 @@
+# Repo discovery
+
+Use repo evidence before asking the user for Mongo details.
+
+## Discovery order
+
+1. Read `AGENTS.md`.
+2. Read repo docs or runbooks related to ADS-B, Mongo, routes, or operations.
+3. Search code for:
+   - database names
+   - collection names
+   - `properties.feeder`
+   - `properties.jsDate`
+   - `$unionWith`
+   - ADS-B route or ingestion code
+
+If the repo still does not establish the target clearly, ask for the missing database, collection, and field-path values.
+
+## CopterSpotter cues
+
+- `copterspotter/.cursor/rules/adsb-feeder-healthcheck.mdc`
+  - Establishes the original runbook behavior
+  - Names `HelicoptersofDC-2023`, `ADSB`, `ADSB-mil`, `properties.feeder`, and `properties.jsDate`
+- `copterspotter/.cursor/rules/adsb-routes.mdc`
+  - Links to the feeder healthcheck runbook as an operational runbook
+- `copterspotter/routes/adsbLookupCore.js`
+  - Confirms the `ADSB` plus `ADSB-mil` aggregation pattern
+  - Confirms `properties.jsDate` usage in Mongo queries
+- `copterspotter/routes/adsbRoutes.js`
+  - Repeats the primary-plus-secondary collection pattern with `$unionWith`
+
+For `copterspotter`, the runbook is the strongest evidence source. Use it first.
+
+## CopterFeeder cues
+
+- `CopterFeeder/AGENTS.md`
+  - Confirms the repo writes rotorcraft data into a MongoDB-backed API flow
+- `CopterFeeder/fcs.py`
+  - Confirms the database name `HelicoptersofDC-2023`
+  - Confirms collection selection between `ADSB` and `ADSB-mil`
+
+`CopterFeeder` does not expose the feeder healthcheck runbook itself, so inspect code before assuming field paths. If field-path evidence is missing in the repo, ask the user to confirm them.
+
+## Unknown repo checklist
+
+Look for one or more of these patterns:
+
+- `db.collection("...")`
+- `myclient["..."]`
+- `$unionWith`
+- `properties.feeder`
+- `properties.jsDate`
+- feeder identifiers written during ingestion
+- report or healthcheck docs that mention ADS-B or feeder recency
+
+If you only find partial evidence, state what was discovered and ask only for the missing values.

--- a/.cursor/skills/adsb-feeder-healthcheck/references/source-runbook-notes.md
+++ b/.cursor/skills/adsb-feeder-healthcheck/references/source-runbook-notes.md
@@ -1,0 +1,37 @@
+# Source runbook mapping
+
+This skill is derived from `copterspotter/.cursor/rules/adsb-feeder-healthcheck.mdc`.
+
+## Section mapping
+
+- Runbook description and prerequisites:
+  - Skill sections `Use This Skill When`, `Workflow`, and `Guardrails`
+  - Converted from repo-specific defaults into a discovery-first workflow
+- Query 1: feeders with data in last N hours:
+  - Skill query mode `feeders active in the last N hours`
+  - Pipeline template in `query-recipes.md` under `Rolling window`
+- Query 2a: last date per feeder across all data:
+  - Skill query mode `last-seen per feeder across all data`
+  - Pipeline template in `query-recipes.md` under `All feeders`
+- Query 2b: feeders matching a name pattern:
+  - Skill query mode `last-seen for feeders matching a substring`
+  - Pipeline template in `query-recipes.md` under `Substring match`
+- Query 3: fixed date range:
+  - Skill query mode `fixed historical date range`
+  - Pipeline template in `query-recipes.md` under `Fixed range`
+- Runbook tips:
+  - Skill guidance to run against the primary collection and use `$unionWith` for the optional secondary collection
+  - Skill reminder that `$dateSubtract` requires MongoDB 5.0 or newer
+
+## What changed during conversion
+
+- Repo defaults are now discovered instead of assumed.
+- Collection names and field paths are parameterized with placeholders.
+- The reporting requirements are explicit so final answers always surface the exact database, collection set, and filter choices used.
+
+## What must stay aligned
+
+- The four supported query modes
+- `$unionWith`-based aggregation across one or two collections
+- Grouping by feeder and reporting the latest timestamp per feeder
+- The rule that runbook behavior wins if generalization would change semantics


### PR DESCRIPTION
## Summary
- add the `adsb-feeder-healthcheck` skill under the repo-local `.agents/skills` directory
- add the same skill under `.cursor/skills` and `.claude/skills` for consistency across agent families
- include the skill instructions, OpenAI agent metadata, and reference documents in each installed copy

## Testing
- verified each installed repo copy matches the source skill directory exactly